### PR TITLE
Bugfix: missing 'and' operator. causes crash when compiling with cython

### DIFF
--- a/primo/linking/intent_filters.pyx
+++ b/primo/linking/intent_filters.pyx
@@ -170,7 +170,7 @@ cdef class IntentFilter(object):
     """
 
     return (self.actions and len(self.actions) >= 1
-            _ACTION_MAIN in self.actions)
+            and _ACTION_MAIN in self.actions)
 
   def print_end_point(self):
     print "package",self.component.application_id


### PR DESCRIPTION
I tried to recompile PRIMO with cython (in a new docker container for my tests). And I realized that I forgot the 'and' operator after having updated the last PR!
Sorry for that, it's now fixed.
