### PR TITLE
Improved the installation process with the list of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+scipy
+Cython
+protobuf
+python-gflags
+bloscpack

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,24 @@ from distutils.extension import Extension
 
 SRC_DIR = 'primo/linking'
 
+NAME = 'primo'
+VERSION = '0.1.0'
+DESCR = 'ICC resolution package.'
+URL = 'http://siis.cse.psu.edu/primo/'
+
+AUTHOR = 'Damien Octeau'
+EMAIL = 'octeau@cse.psu.edu'
+
+LICENSE = 'Apache 2.0'
+
+REQUIRES = ['numpy', 'scipy', 'protobuf', 'python-gflags', 'bloscpack']
+
+PACKAGES = ['primo', 'primo.linking']
+SCRIPTS = ['bin/primo', 'bin/make_plots_and_stats',
+      'bin/performance_experiments']
+CMD_CLASS = {}
+OPTIONS = {}
+
 
 if glob.glob(os.path.join(SRC_DIR, '*.c')):
   use_cython = False
@@ -55,22 +73,6 @@ def ScanDir(directory, file_extension, files=[]):
       ScanDir(file_path, file_extension, files)
   return files
 
-NAME = 'primo'
-VERSION = '0.1.0'
-DESCR = 'ICC resolution package.'
-URL = 'http://siis.cse.psu.edu/primo/'
-
-AUTHOR = 'Damien Octeau'
-EMAIL = 'octeau@cse.psu.edu'
-
-LICENSE = 'Apache 2.0'
-
-PACKAGES = ['primo', 'primo.linking']
-SCRIPTS = ['bin/primo', 'bin/make_plots_and_stats',
-      'bin/performance_experiments']
-CMD_CLASS = {}
-OPTIONS = {}
-
 
 def MakeExtension(ext_name, file_extension):
   """Generates an Extension object from its dotted name."""
@@ -84,11 +86,13 @@ def MakeExtension(ext_name, file_extension):
       extra_link_args = ['-g'],
       )
 
+
 if __name__ == "__main__":
   if use_cython:
     extension = '.pyx'
     CMD_CLASS['build_ext'] = build_ext
     OPTIONS['build_ext'] = {'inplace':True}
+    REQUIRES.append('Cython')
   else:
     extension = '.c'
 
@@ -107,6 +111,7 @@ if __name__ == "__main__":
         url=URL,
         scripts=SCRIPTS,
         license=LICENSE,
+        install_requires=REQUIRES,
         cmdclass=CMD_CLASS,
         ext_modules=extensions,
         options=OPTIONS

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
   # And build up the set of Extension objects.
   extensions = [MakeExtension(name, extension) for name in ext_names]
   if USE_CYTHON:
-      extensions = cythonize(extensions)
+    extensions = cythonize(extensions)
 
   setup(packages=PACKAGES,
         name=NAME,


### PR DESCRIPTION
I have added the requirements ('numpy', 'scipy', 'protobuf', 'python-gflags', 'bloscpack') to the setup.py file. The requirements are provided through the 'install_requires' parameter of the setuptools.setup() function. Consequently I am now using the function build_ext() from setuptools.command.build_ext.

I did that in order to ease the installation process with the dependencies. This is useful for my automated tests in a project which is using PRIMO. And I think that this is a little improvement, especially if in the future you want to upload the project on pypi.
